### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,7 @@ dependencies {
 	include xplibs.task
 
 	include libs.lib.admin.ui
-	include(libs.lib.galimatias) {
-		exclude group: 'com.enonic.xp'
-	}
+	include libs.lib.galimatias
 	include libs.lib.http.client
 	include libs.lib.license
 	include libs.lib.router

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 lib-admin-ui = "4.3.4"
-lib-galimatias = "1.0.0"
-lib-http-client = "3.2.2"
+lib-galimatias = "2.0.0-SNAPSHOT"
+lib-http-client = "4.0.0-SNAPSHOT"
 lib-license = "3.1.0"
 lib-router = "3.2.0"
 lib-static = "2.1.1"


### PR DESCRIPTION
## Summary

Now that **lib-galimatias** and **lib-http-client** have landed XP 8 upgrades on their `master` branches, pin this app to the new SNAPSHOTs.

### Version bumps (`gradle/libs.versions.toml`)

| Library | Old | New |
|---|---|---|
| `com.enonic.lib:lib-galimatias` | `1.0.0` | `2.0.0-SNAPSHOT` |
| `com.enonic.lib:lib-http-client` | `3.2.2` | `4.0.0-SNAPSHOT` |

Both resolve from the existing `xp.enonicRepo("dev")` declaration; no repo changes needed.

### `build.gradle` — drop the `com.enonic.xp` exclude on lib-galimatias

After the XP 8 upgrade, lib-galimatias 2.0.0-SNAPSHOT declares its XP deps via `xplibs.*` aliases (verified below — they come in as `compileOnly`-equivalent transitives at the platform's `8.0.0-B4`, version-aligned with the rest of `include`), so the previous `exclude group: 'com.enonic.xp'` is a no-op. Collapsed to a plain `include libs.lib.galimatias`.

### Audit of other `com.enonic.lib:*` includes

`build.gradle` had only the one stale exclude (on lib-galimatias). The remaining `com.enonic.lib:*` `include(...)` calls — `lib-admin-ui`, `lib-http-client`, `lib-license`, `lib-router`, `lib-static`, `lib-text-encoding` — already have no excludes, so nothing to clean up.

### Verification

- `./gradlew clean build` is green locally.
- `./gradlew dependencies --configuration include --refresh-dependencies` confirms both new SNAPSHOTs resolve and there is no `com.enonic.xp:*` version leakage from them (XP transitives from lib-galimatias come in at the same `8.0.0-B4` as the direct `xplibs.*` includes).
- Runtime / deploy verification was **not performed** for this PR.

## Test plan

- [ ] CI build passes on `chore/bump-enonic-libs-xp8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)