### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "2.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ appName = com.enonic.app.fotoware
 xpVersion=8.0.0-B4
 
 nodeVersion=18.16.0
-version=2.0.3-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump `version` on master from `2.0.3-SNAPSHOT` to `3.0.0-SNAPSHOT` to start the XP 8 major.
- Add `releaseBranch:` block in `enonic-gradle.yml` so both `master` and `2.x` are recognized as release branches by the release tooling.
- Add `2.x` to `enonic-docgen.yml` push branches so docs are generated from the maintenance line too.
- Add `docs/versions.json` mapping `stable` → `2.x` and `next` → `master`.

The XP 7 maintenance line continues on the new `2.x` branch (created from the post-`v2.1.0-RC2` SNAPSHOT commit).

## Test plan
- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` from master is green