### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` block in `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so the release tooling recognizes pushes to `2.x` as release-branch builds.

The `releaseBranch` setting is read from each branch's own workflow file, so `2.x` needs its own copy of this config (in addition to the matching change on master). No version bump, no docgen change, no `versions.json` here — those are master-only.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, a CI run on `2.x` classifies it as a release branch