### PR TITLE
Bump lib-license to 4.0.0-SNAPSHOT #201

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 lib-admin-ui = "4.3.4"
 lib-galimatias = "2.0.0-SNAPSHOT"
 lib-http-client = "4.0.0-SNAPSHOT"
-lib-license = "3.1.0"
+lib-license = "4.0.0-SNAPSHOT"
 lib-router = "3.2.0"
 lib-static = "2.1.1"
 lib-text-encoding = "2.1.1"


### PR DESCRIPTION
## Summary

`lib-license` `3.1.0` (the version pinned in `gradle/libs.versions.toml`) fails to instantiate on XP 8 with:

```
NoSuchMethodError: 'com.enonic.xp.node.NodePath$Builder com.enonic.xp.node.NodePath.create(com.enonic.xp.node.NodePath, java.lang.String)'
    at com.enonic.lib.license.LicenseManagerImpl.<clinit>(LicenseManagerImpl.java:72)
```

The `LicenseManager` OSGi service then never registers, so every webapp endpoint that gates on `validateLicense({...})` (e.g. `/asset/ingested`, `/asset/modified`, `/export/published`, …) and the `licenseValid` service throw `ResourceProblemException: Service [com.enonic.lib.license.LicenseManager] not found`.

`com.enonic.lib:lib-license:4.0.0-SNAPSHOT` (already published to `repo.enonic.com/dev`) is compiled against the current XP 8 `NodePath` API and resolves the breakage.

## Test plan

- [x] E2E in `claude-dev` (`/tmp/xp-e2e-fotoware-*`) at XP `8.0.0-B4` (the version declared in `gradle.properties`)
- [x] Before patch: bundle reaches ACTIVE but `LicenseManagerImpl` instantiation ERRORs out at boot and `POST /webapp/com.enonic.app.fotoware/asset/ingested` returns HTTP 500 — `Service [com.enonic.lib.license.LicenseManager] not found`
- [x] After patch: no `LicenseManagerImpl` ERROR in `server.log`; `POST /webapp/com.enonic.app.fotoware/asset/ingested` returns HTTP 404 with the script's expected `Unlicensed!` log line (license-gated 404, app working as designed since no license is installed in the smoke env)
- [x] Webapp root `/webapp/com.enonic.app.fotoware/` serves `application.svg` (HTTP 200) both before and after
- [ ] CI green

Closes #201