### PR TITLE
Drop version-history clutter from docs #211

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -59,8 +59,6 @@ imports.myimport.project = myproject // <8>
 
 === Metadata mappings
 
-NOTE: This feature is available from version 2.0.2
-
 The integration allows you to map metadata from FotoWare to Enonic. This is done by specifying the metadata field in FotoWare and the corresponding field in Enonic.
 
 Here is an example using the default configuration:


### PR DESCRIPTION
## Summary
- Removed the "This feature is available from version 2.0.2" note in the Metadata mappings section — no longer meaningful on the current docs branch (`master` is XP 8; XP 7 docs are on `2.x`).

## Kept deliberately
- The IMPORTANT block that says "Make certain you have selected version 2 format under the asset modified webhook configuration." — this is about FotoWare's webhook payload version, not app-fotoware version history. Still a current, useful caveat.

## Out of scope
- No branch changes, no `versions.json` restructuring, `2.x` untouched (per task decision).

## Test plan
- [x] `asciidoc docs/index.adoc` renders (warning count matches `master` — 17 pre-existing, all from missing `source-highlight` and legacy-asciidoc callout parsing; no new warnings, no broken includes/attributes).

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)