### PR TITLE
GraalJS Compatibility #215

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 	testImplementation "com.enonic.xp:testing:${xpVersion}"
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
-	testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 
@@ -99,18 +98,9 @@ test {
 	useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-	dependsOn npmBuild
-	group = 'verification'
-	description = 'Runs tests with the GraalJS script engine.'
-	useJUnitPlatform()
-	testClassesDirs = sourceSets.test.output.classesDirs
-	classpath = sourceSets.test.runtimeClasspath
-	systemProperty 'xp.script-engine', 'GraalJS'
-	shouldRunAfter test
+xp {
+	scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs
 
 processResources {
 	exclude '**/.gitkeep'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
 	include libs.lib.router
 	include libs.lib.static
 	include libs.lib.text.encoding
+
+	testImplementation "com.enonic.xp:testing:${xpVersion}"
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
+	testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 
@@ -84,6 +89,28 @@ task npmBuild(type: NpmTask) {
 }
 
 jar.dependsOn npmBuild
+
+tasks.named('compileTestJava') {
+	dependsOn npmBuild
+}
+
+test {
+	dependsOn npmBuild
+	useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+	dependsOn npmBuild
+	group = 'verification'
+	description = 'Runs tests with the GraalJS script engine.'
+	useJUnitPlatform()
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+	systemProperty 'xp.script-engine', 'GraalJS'
+	shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 processResources {
 	exclude '**/.gitkeep'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectName = fotoware
 appName = com.enonic.app.fotoware
 
 # Latest released XP 8 version
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 
 nodeVersion=18.16.0
 version=3.0.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.enonic.xp.settings' version '4.1.0'
+	id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -14,7 +14,6 @@ import {
 	create as createRepo,
 	list as listRepos
 }  from '/lib/xp/repo';
-import {executeFunction} from '/lib/xp/task';
 
 runInContext({
 	repository: 'system-repo',
@@ -24,48 +23,45 @@ runInContext({
 		idProvider: 'system'
 	},
 	principals: ['role:system.admin']
-}, () => executeFunction({
-	description: `Creating repoId:${REPO_ID} branch:${REPO_BRANCH} (if needed)`,
-	func: () => {
-		const repoList = listRepos();
-		//log.debug(`repoList:${toStr(repoList)}`);
+}, () => {
+	const repoList = listRepos();
+	//log.debug(`repoList:${toStr(repoList)}`);
 
-		const reposObj: Record<string, {
-			branches: string[]
-		}> = {};
-		repoList.forEach(({id, branches}) => {
-			reposObj[id] = {branches};
+	const reposObj: Record<string, {
+		branches: string[]
+	}> = {};
+	repoList.forEach(({id, branches}) => {
+		reposObj[id] = {branches};
+	});
+	//log.debug(`reposObj:${toStr(reposObj)}`);
+
+	if (!reposObj[REPO_ID]) {
+		//const createRes =
+		createRepo({
+			id: REPO_ID,
+			rootPermissions: PERMISSIONS,
+			rootChildOrder: CHILD_ORDER
 		});
-		//log.debug(`reposObj:${toStr(reposObj)}`);
+		//log.debug(`createRes:${toStr(createRes)}`);
+	} // if !repo
 
-		if (!reposObj[REPO_ID]) {
-			//const createRes =
-			createRepo({
-				id: REPO_ID,
-				rootPermissions: PERMISSIONS,
-				rootChildOrder: CHILD_ORDER
-			});
-			//log.debug(`createRes:${toStr(createRes)}`);
-		} // if !repo
+	const suConnection = connect({
+		repoId: REPO_ID,
+		branch: REPO_BRANCH
+	});
 
-		const suConnection = connect({
-			repoId: REPO_ID,
-			branch: REPO_BRANCH
+	const boolTaskFolderExists = suConnection.exists(TASKS_FOLDER_PATH);
+	//log.debug(`boolTaskFolderExists:${toStr(boolTaskFolderExists)}`);
+
+	if (!boolTaskFolderExists) {
+		//const nodeCreateRes =
+		suConnection.create({
+			_parentPath: TASKS_FOLDER_PARENT_PATH,
+			_name: TASKS_FOLDER_NAME,
+			_inheritsPermissions: true,
+			_childOrder: CHILD_ORDER,
+			displayName: 'Tasks'
 		});
-
-		const boolTaskFolderExists = suConnection.exists(TASKS_FOLDER_PATH);
-		//log.debug(`boolTaskFolderExists:${toStr(boolTaskFolderExists)}`);
-
-		if (!boolTaskFolderExists) {
-			//const nodeCreateRes =
-			suConnection.create({
-				_parentPath: TASKS_FOLDER_PARENT_PATH,
-				_name: TASKS_FOLDER_NAME,
-				_inheritsPermissions: true,
-				_childOrder: CHILD_ORDER,
-				displayName: 'Tasks'
-			});
-			//log.debug(`nodeCreateRes:${toStr(nodeCreateRes)}`);
-		}
-	} // task
-}));
+		//log.debug(`nodeCreateRes:${toStr(nodeCreateRes)}`);
+	}
+});

--- a/src/test/java/com/enonic/app/fotoware/MainScriptTest.java
+++ b/src/test/java/com/enonic/app/fotoware/MainScriptTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.fotoware;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class MainScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/main-test.js";
+    }
+}

--- a/src/test/resources/test/main-test.js
+++ b/src/test/resources/test/main-test.js
@@ -1,0 +1,76 @@
+var t = require('/lib/xp/testing');
+
+var calls = {
+    contextRun: 0,
+    repoList: 0,
+    repoCreate: 0,
+    createdRepoId: null,
+    nodeConnect: 0,
+    nodeExists: 0,
+    existsPath: null,
+    nodeCreate: 0,
+    createdNodeName: null
+};
+
+t.mock('/lib/fotoware/xp/constants.js', {
+    REPO_ID: 'com.enonic.app.fotoware',
+    REPO_BRANCH: 'master',
+    PERMISSIONS: [],
+    CHILD_ORDER: '_ts DESC',
+    TASKS_FOLDER_PARENT_PATH: '/',
+    TASKS_FOLDER_NAME: 'tasks',
+    TASKS_FOLDER_PATH: '/tasks'
+});
+
+t.mock('/lib/xp/context.js', {
+    run: function (params, callback) {
+        calls.contextRun++;
+        return callback();
+    }
+});
+
+t.mock('/lib/xp/repo.js', {
+    list: function () {
+        calls.repoList++;
+        return [];
+    },
+    create: function (params) {
+        calls.repoCreate++;
+        calls.createdRepoId = params.id;
+        return {
+            id: params.id
+        };
+    }
+});
+
+t.mock('/lib/xp/node.js', {
+    connect: function () {
+        calls.nodeConnect++;
+        return {
+            exists: function (path) {
+                calls.nodeExists++;
+                calls.existsPath = path;
+                return false;
+            },
+            create: function (node) {
+                calls.nodeCreate++;
+                calls.createdNodeName = node._name;
+                return node;
+            }
+        };
+    }
+});
+
+require('/main.js');
+
+exports.testInitCreatesRepoAndTasksFolderSynchronously = function () {
+    t.assertEquals(1, calls.contextRun, 'runInContext should be called once');
+    t.assertEquals(1, calls.repoList, 'repo.list should be called once');
+    t.assertEquals(1, calls.repoCreate, 'repo.create should be called once when repo is missing');
+    t.assertEquals('com.enonic.app.fotoware', calls.createdRepoId, 'created repo id');
+    t.assertEquals(1, calls.nodeConnect, 'node.connect should be called once');
+    t.assertEquals(1, calls.nodeExists, 'connection.exists should be called once');
+    t.assertEquals('/tasks', calls.existsPath, 'exists should check the tasks folder path');
+    t.assertEquals(1, calls.nodeCreate, 'tasks folder should be created when missing');
+    t.assertEquals('tasks', calls.createdNodeName, 'created tasks folder name');
+};


### PR DESCRIPTION
Fixes #215

## What

`main.ts` offloaded first-boot initialization (create the app repo + `/tasks` folder) through `task.executeFunction`. That API cannot be honored on GraalJS — a function is bound to the context that created it — so it **fails fast on GraalJS and the app cannot initialize at all** on that engine.

The offload no longer has a purpose either: enonic/xp#12198 holds every top-level execution until `main.js` has finished, so nothing observes the app before init completes. The fix is to drop the `executeFunction` wrapper and run the body directly inside the existing `runInContext(...)`. The `description` (task-list label) is the only thing lost.

```diff
-import {executeFunction} from '/lib/xp/task';
...
-}, () => executeFunction({
-    description: `Creating repoId:${REPO_ID} branch:${REPO_BRANCH} (if needed)`,
-    func: () => {
-        ...
-    } // task
-}));
+}, () => {
+    ...
+});
```

## Tested on both engines

The JS tests now run once per script engine — Nashorn via `test` (the platform default) and GraalJS via `testGraalJs` — both wired into `check`, mirroring `gradle/js-tests.gradle` in the platform (reference: enonic/lib-sql#154).

A new `MainScriptTest` (`ScriptRunnerSupport`) loads the compiled `main.js` with `/lib/xp/{context,node,repo}` and `/lib/fotoware/xp/constants` mocked, and asserts the repo + `/tasks` folder are created **synchronously during `require`** — which the `executeFunction` offload would not do.

Verified locally against a `publishToMavenLocal` build of enonic/xp#12198:

```
test         MainScriptTest  1 test, 0 failed   (Nashorn)
testGraalJs  MainScriptTest  1 test, 0 failed   (GraalJS)
```

The existing `jest` suite (55 tests) stays green.

## Note on `xpVersion`

The bump to `8.1.0-SNAPSHOT` (with `enonicRepo('dev')`, already present) is required by `testGraalJs`, not by the source fix — `ScriptRunnerSupport` closed the script executor during JS test discovery, so on GraalJS every test failed with `IllegalStateException: The Context is already closed` regardless of this app's code. That is fixed in enonic/xp#12198.

**CI `testGraalJs` will stay red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published** — the snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`. Holding this as a **draft** until then.

## Not in this PR

Per the issue, the three request/hook-path `executeFunction` call sites — `webapp/assetDeleted.ts`, `webapp/assetIngested.ts`, `tasks/handleAssetModifiedHook/modifyInImport.ts` — genuinely need to run away from the caller and should become **named tasks** (not direct calls, which would block the webhook response). That is a separate, larger change with no exact recipe in the issue and is left as follow-up; this PR covers only the initialization offload (`main.ts`), the part that blocks app startup on GraalJS.